### PR TITLE
Add verification pipeline skeleton and mobility rights smart contracts

### DIFF
--- a/contracts/EmergencyMobilityResponse.sol
+++ b/contracts/EmergencyMobilityResponse.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+interface MobilityRightsProtocol {
+    function issueRight(bytes32, string memory, uint8, uint256, bytes32) external;
+}
+
+interface MobilityPricingOracle {
+    function setEmergencyPricing(string memory, int256) external;
+}
+
+contract EmergencyMobilityResponse {
+    struct EmergencyEvent {
+        string eventType;
+        string[] affectedRegions;
+        uint256 severity;
+        uint256 startTime;
+        bool active;
+    }
+
+    mapping(bytes32 => EmergencyEvent) public emergencies;
+
+    address public rightsContract;
+    address public pricingOracle;
+    address public authorized;
+
+    modifier onlyAuthorized() {
+        require(msg.sender == authorized, "Not authorized");
+        _;
+    }
+
+    constructor(address _rightsContract, address _pricingOracle, address _auth) {
+        rightsContract = _rightsContract;
+        pricingOracle = _pricingOracle;
+        authorized = _auth;
+    }
+
+    function declareEmergency(
+        string memory _eventType,
+        string[] memory _affectedRegions,
+        uint256 _severity
+    ) external onlyAuthorized {
+        bytes32 emergencyId = keccak256(
+            abi.encodePacked(_eventType, block.timestamp)
+        );
+
+        emergencies[emergencyId] = EmergencyEvent({
+            eventType: _eventType,
+            affectedRegions: _affectedRegions,
+            severity: _severity,
+            startTime: block.timestamp,
+            active: true
+        });
+
+        for (uint256 i = 0; i < _affectedRegions.length; i++) {
+            MobilityPricingOracle(pricingOracle).setEmergencyPricing(
+                _affectedRegions[i],
+                -10000 * 10**18
+            );
+        }
+    }
+
+    function emergencyVerification(
+        bytes32 _userDID,
+        string memory _originRegion,
+        bytes32 _emergencyId
+    ) external {
+        EmergencyEvent memory emergency = emergencies[_emergencyId];
+        require(emergency.active, "No active emergency");
+        MobilityRightsProtocol(rightsContract).issueRight(
+            _userDID,
+            "temporary_protection",
+            10,
+            180 days,
+            _emergencyId
+        );
+    }
+}

--- a/contracts/MobilityPricingOracle.sol
+++ b/contracts/MobilityPricingOracle.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+interface MobilityRightsProtocol {
+    function updatePrice(string memory, string memory, int256) external;
+}
+
+contract MobilityPricingOracle {
+    struct MarketData {
+        uint256 talentDemand;
+        uint256 talentSupply;
+        uint256 averageSalary;
+        uint256 economicImpact;
+        uint256 lastUpdated;
+    }
+
+    mapping(string => mapping(string => MarketData)) public marketMetrics;
+    mapping(string => mapping(string => int256)) public dynamicPrices;
+
+    address public rightsContract;
+    address public oracle;
+
+    modifier onlyOracle() {
+        require(msg.sender == oracle, "Not oracle");
+        _;
+    }
+
+    constructor(address _rightsContract, address _oracle) {
+        rightsContract = _rightsContract;
+        oracle = _oracle;
+    }
+
+    function calculateExecutionPrice(
+        string memory _country,
+        string memory _rightType
+    ) public view returns (int256) {
+        MarketData memory data = marketMetrics[_country][_rightType];
+        int256 price = 1000 * 10**18;
+        if (data.talentDemand > data.talentSupply * 2) {
+            price = -int256(data.averageSalary / 10);
+        } else if (data.talentSupply > data.talentDemand * 2) {
+            price = price * 3;
+        }
+        price = (price * int256(100 - data.economicImpact)) / 100;
+        return price;
+    }
+
+    function updateMarketData(
+        string memory _country,
+        string memory _rightType,
+        uint256 _demand,
+        uint256 _supply,
+        uint256 _avgSalary,
+        uint256 _economicImpact
+    ) external onlyOracle {
+        marketMetrics[_country][_rightType] = MarketData({
+            talentDemand: _demand,
+            talentSupply: _supply,
+            averageSalary: _avgSalary,
+            economicImpact: _economicImpact,
+            lastUpdated: block.timestamp
+        });
+
+        int256 newPrice = calculateExecutionPrice(_country, _rightType);
+        dynamicPrices[_country][_rightType] = newPrice;
+        MobilityRightsProtocol(rightsContract).updatePrice(
+            _country,
+            _rightType,
+            newPrice
+        );
+    }
+
+    function setEmergencyPricing(string memory _rightType, int256 _price) external onlyOracle {
+        dynamicPrices["emergency"][_rightType] = _price;
+    }
+}

--- a/contracts/MobilityRightsProtocol.sol
+++ b/contracts/MobilityRightsProtocol.sol
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+contract MobilityRightsProtocol {
+    struct MobilityRight {
+        string rightType;
+        uint8 level;
+        uint256 issuedAt;
+        uint256 expiresAt;
+        bytes32 evidenceHash;
+        address issuer;
+        bool revoked;
+    }
+
+    struct RightsExecution {
+        address holder;
+        string destinationCountry;
+        string rightType;
+        uint256 executionFee;
+        uint256 timestamp;
+        ExecutionStatus status;
+        bytes32 conditionsHash;
+    }
+
+    enum ExecutionStatus {
+        Pending,
+        Approved,
+        Active,
+        Completed,
+        Revoked
+    }
+
+    mapping(bytes32 => MobilityRight[]) public userRights;
+    mapping(string => mapping(string => int256)) public executionPrices;
+    mapping(bytes32 => RightsExecution) public executions;
+    mapping(address => uint256) public reputationStakes;
+
+    event RightIssued(bytes32 indexed userDID, string rightType, uint8 level);
+    event RightExecuted(bytes32 indexed executionId, address holder, string destination);
+    event PriceUpdated(string country, string rightType, int256 newPrice);
+    event RightRevoked(bytes32 indexed userDID, string rightType, string reason);
+
+    modifier onlyAuthorizedIssuer() {
+        _;
+    }
+
+    function issueRight(
+        bytes32 _userDID,
+        string memory _rightType,
+        uint8 _level,
+        uint256 _duration,
+        bytes32 _evidenceHash
+    ) external onlyAuthorizedIssuer {
+        require(_level >= 1 && _level <= 10, "Invalid level");
+
+        MobilityRight memory newRight = MobilityRight({
+            rightType: _rightType,
+            level: _level,
+            issuedAt: block.timestamp,
+            expiresAt: block.timestamp + _duration,
+            evidenceHash: _evidenceHash,
+            issuer: msg.sender,
+            revoked: false
+        });
+
+        userRights[_userDID].push(newRight);
+
+        emit RightIssued(_userDID, _rightType, _level);
+    }
+
+    function executeRight(
+        bytes32 _userDID,
+        string memory _rightType,
+        string memory _destination,
+        bytes32 _conditionsHash
+    ) external payable returns (bytes32 executionId) {
+        require(hasValidRight(_userDID, _rightType), "No valid right");
+
+        int256 price = executionPrices[_destination][_rightType];
+
+        if (price > 0) {
+            require(msg.value >= uint256(price), "Insufficient payment");
+        } else if (price < 0) {
+            payable(msg.sender).transfer(uint256(-price));
+        }
+
+        executionId = keccak256(
+            abi.encodePacked(_userDID, _destination, block.timestamp)
+        );
+
+        executions[executionId] = RightsExecution({
+            holder: msg.sender,
+            destinationCountry: _destination,
+            rightType: _rightType,
+            executionFee: msg.value,
+            timestamp: block.timestamp,
+            status: ExecutionStatus.Pending,
+            conditionsHash: _conditionsHash
+        });
+
+        if (getMobilityScore(_userDID, _rightType) >= getCountryThreshold(_destination)) {
+            executions[executionId].status = ExecutionStatus.Approved;
+        }
+
+        emit RightExecuted(executionId, msg.sender, _destination);
+    }
+
+    function hasValidRight(bytes32, string memory) internal pure returns (bool) {
+        return true;
+    }
+
+    function getMobilityScore(bytes32, string memory) internal pure returns (uint256) {
+        return 0;
+    }
+
+    function getCountryThreshold(string memory) internal pure returns (uint256) {
+        return 0;
+    }
+
+    function updatePrice(
+        string memory _country,
+        string memory _rightType,
+        int256 _newPrice
+    ) external {
+        executionPrices[_country][_rightType] = _newPrice;
+        emit PriceUpdated(_country, _rightType, _newPrice);
+    }
+
+    function revokeRight(bytes32, string memory) external {}
+}

--- a/contracts/RightsComposer.sol
+++ b/contracts/RightsComposer.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+interface MobilityRightsProtocol {
+    function issueRight(bytes32, string memory, uint8, uint256, bytes32) external;
+}
+
+contract RightsComposer {
+    address public rightsContract;
+
+    constructor(address _rightsContract) {
+        rightsContract = _rightsContract;
+    }
+
+    function composeRights(bytes32 _userDID, string[] memory _rightTypes)
+        external
+        returns (string memory composedRight)
+    {
+        if (_rightTypes.length == 2) {
+            composedRight = string.concat(_rightTypes[0], "_", _rightTypes[1]);
+            uint8 level = 5;
+            MobilityRightsProtocol(rightsContract).issueRight(
+                _userDID,
+                composedRight,
+                level,
+                365 days * 5,
+                keccak256(abi.encode(_rightTypes))
+            );
+        }
+    }
+
+    function delegateRight(
+        bytes32 _fromDID,
+        bytes32 _toDID,
+        string memory _rightType,
+        uint256 _duration,
+        bytes32 _relationshipProof
+    ) external {
+        uint8 delegatedLevel = 1;
+        MobilityRightsProtocol(rightsContract).issueRight(
+            _toDID,
+            string.concat(_rightType, "_delegated"),
+            delegatedLevel,
+            _duration,
+            _relationshipProof
+        );
+    }
+}

--- a/contracts/SponsorshipStaking.sol
+++ b/contracts/SponsorshipStaking.sol
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+interface MobilityRightsProtocol {
+    function issueRight(bytes32, string memory, uint8, uint256, bytes32) external;
+    function revokeRight(bytes32, string memory) external;
+}
+
+interface IEmploymentVerifier {
+    function verifyEmployment(bytes32, bytes32) external returns (bool);
+}
+
+interface IPayrollOracle {
+    function verifySalary(bytes32, uint256) external returns (bool);
+}
+
+contract SponsorshipStaking {
+    struct SponsorshipConditions {
+        uint256 minimumSalary;
+        string requiredRole;
+        bytes32 employmentContractHash;
+        uint256 performanceThreshold;
+    }
+
+    struct Sponsorship {
+        address sponsor;
+        bytes32 beneficiaryDID;
+        uint256 stakeAmount;
+        string rightType;
+        uint256 startTime;
+        uint256 duration;
+        bool active;
+        SponsorshipConditions conditions;
+    }
+
+    mapping(bytes32 => Sponsorship) public sponsorships;
+    mapping(address => uint256) public sponsorReputation;
+
+    uint256 public constant MIN_STAKE = 10000 * 10**18;
+    uint256 public constant REPUTATION_SLASH_PERCENTAGE = 20;
+
+    address public rightsContract;
+    address public employmentVerifier;
+    address public payrollOracle;
+
+    constructor(address _rightsContract) {
+        rightsContract = _rightsContract;
+    }
+
+    function sponsorMobility(
+        bytes32 _beneficiaryDID,
+        string memory _rightType,
+        uint256 _duration,
+        SponsorshipConditions memory _conditions
+    ) external payable {
+        require(msg.value >= MIN_STAKE, "Insufficient stake");
+        require(sponsorReputation[msg.sender] >= 100, "Insufficient reputation");
+
+        bytes32 sponsorshipId = keccak256(
+            abi.encodePacked(msg.sender, _beneficiaryDID, block.timestamp)
+        );
+
+        sponsorships[sponsorshipId] = Sponsorship({
+            sponsor: msg.sender,
+            beneficiaryDID: _beneficiaryDID,
+            stakeAmount: msg.value,
+            rightType: _rightType,
+            startTime: block.timestamp,
+            duration: _duration,
+            active: true,
+            conditions: _conditions
+        });
+
+        MobilityRightsProtocol(rightsContract).issueRight(
+            _beneficiaryDID,
+            _rightType,
+            5,
+            _duration,
+            keccak256(abi.encode(_conditions))
+        );
+    }
+
+    function verifyConditions(bytes32 _sponsorshipId) external {
+        Sponsorship storage sponsorship = sponsorships[_sponsorshipId];
+        require(sponsorship.active, "Sponsorship inactive");
+
+        bool employed = IEmploymentVerifier(employmentVerifier).verifyEmployment(
+            sponsorship.beneficiaryDID,
+            sponsorship.conditions.employmentContractHash
+        );
+
+        bool salaryMet = IPayrollOracle(payrollOracle).verifySalary(
+            sponsorship.beneficiaryDID,
+            sponsorship.conditions.minimumSalary
+        );
+
+        if (!employed || !salaryMet) {
+            uint256 slashAmount =
+                (sponsorship.stakeAmount * REPUTATION_SLASH_PERCENTAGE) / 100;
+            sponsorReputation[sponsorship.sponsor] -= 50;
+            sponsorship.active = false;
+            MobilityRightsProtocol(rightsContract).revokeRight(
+                sponsorship.beneficiaryDID,
+                sponsorship.rightType
+            );
+        }
+    }
+}

--- a/src/identity/verificationPipeline.ts
+++ b/src/identity/verificationPipeline.ts
@@ -1,0 +1,158 @@
+import { randomUUID } from "crypto";
+
+export interface Credential {
+  id: string;
+  type: string;
+  issuer: string;
+  claim: Record<string, unknown>;
+  proof: string;
+  timestamp: string;
+  verification_status: "pending" | "verified" | "expired";
+  verification_method: "document" | "api" | "attestation";
+}
+
+export class DocumentIngestion {
+  process(document: unknown) {
+    // Placeholder implementation for document processing
+    return {
+      rawData: document,
+      verificationRequirements: [],
+      confidenceScore: 0,
+      fraudRiskScore: 0,
+    };
+  }
+}
+
+interface VerificationPath {
+  method: string;
+  result: boolean;
+  weight: number;
+}
+
+export class VerificationOrchestrator {
+  verifyCredential(_credentialData: Credential) {
+    const verificationPaths: VerificationPath[] = [
+      { method: "document_analysis", result: true, weight: 0.6 },
+    ];
+
+    const score = verificationPaths.reduce((acc, path) => {
+      return acc + (path.result ? path.weight : 0);
+    }, 0);
+
+    return {
+      verified: score > 0.8,
+      confidence: score,
+      methodsUsed: verificationPaths,
+      timestamp: new Date().toISOString(),
+      expires: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString(),
+    };
+  }
+}
+
+export class CredentialSigner {
+  createVerifiableCredential(verifiedData: Credential) {
+    const credential = {
+      id: `https://example.org/credentials/${randomUUID()}`,
+      type: ["VerifiableCredential", verifiedData.type],
+      issuer: "did:jg:justiguide",
+      issuanceDate: new Date().toISOString(),
+      expirationDate: new Date(
+        Date.now() + 365 * 24 * 60 * 60 * 1000
+      ).toISOString(),
+      credentialSubject: {
+        id: verifiedData.issuer,
+        claim: verifiedData.claim,
+      },
+    };
+
+    // Placeholder proof generation
+    const proof = {
+      type: "RsaSignature2018",
+      created: new Date().toISOString(),
+      creator: "did:jg:justiguide#keys-1",
+      signatureValue: "placeholder",
+    };
+
+    return { ...credential, proof };
+  }
+}
+
+export interface MobilityRight {
+  type: string;
+  level: number;
+  evidence: string[];
+}
+
+export class RightsCalculator {
+  calculateMobilityRights(credentials: Credential[]): MobilityRight[] {
+    // Simplified rights calculation
+    const rights: MobilityRight[] = [];
+    const educationCreds = credentials.filter((c) => c.type === "education");
+    if (educationCreds.length > 0) {
+      rights.push({
+        type: "skilled_worker",
+        level: 1,
+        evidence: [educationCreds[0].id],
+      });
+    }
+    return rights;
+  }
+}
+
+export class RightsPropagator {
+  async propagateRights(_userDid: string, rights: MobilityRight[]) {
+    // Placeholder async propagation
+    return {
+      propagationComplete: true,
+      networksUpdated: rights.length,
+      portableCredential: rights,
+      timestamp: new Date().toISOString(),
+    };
+  }
+}
+
+export function examplePipeline(document: unknown) {
+  const ingestion = new DocumentIngestion();
+  const orchestrator = new VerificationOrchestrator();
+  const signer = new CredentialSigner();
+  const calculator = new RightsCalculator();
+  const propagator = new RightsPropagator();
+
+  const processed = ingestion.process(document);
+  const verification = orchestrator.verifyCredential({
+    id: randomUUID(),
+    type: "education",
+    issuer: "did:example:issuer",
+    claim: processed.rawData as Record<string, unknown>,
+    proof: "",
+    timestamp: new Date().toISOString(),
+    verification_status: "pending",
+    verification_method: "document",
+  });
+
+  const credential = signer.createVerifiableCredential({
+    id: randomUUID(),
+    type: "education",
+    issuer: "did:example:issuer",
+    claim: {},
+    proof: "",
+    timestamp: new Date().toISOString(),
+    verification_status: "verified",
+    verification_method: "api",
+  });
+
+  const rights = calculator.calculateMobilityRights([
+    {
+      id: credential.id,
+      type: "education",
+      issuer: credential.issuer,
+      claim: {},
+      proof: credential.proof.signatureValue,
+      timestamp: credential.issuanceDate,
+      verification_status: "verified",
+      verification_method: "api",
+    },
+  ]);
+
+  return propagator.propagateRights(credential.issuer, rights);
+}


### PR DESCRIPTION
## Summary
- scaffold verification pipeline in TypeScript with credential handling, signing, and rights propagation
- add Solidity contracts for mobility rights execution, sponsorship staking, pricing oracle, rights composition, and emergency response

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` *(fails: TypeError: fetch failed in tests/e2e/oidc-route.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6895168c4c8083228a780c7e8aa55d4c